### PR TITLE
analytics working with view transitions

### DIFF
--- a/.changeset/short-vans-cry.md
+++ b/.changeset/short-vans-cry.md
@@ -1,0 +1,5 @@
+---
+"@astroutils/analytics": minor
+---
+
+working with view transitions (fixes #3)

--- a/apps/analytics/src/components/Umami.astro
+++ b/apps/analytics/src/components/Umami.astro
@@ -1,0 +1,5 @@
+---
+import { Analytics } from "@astroutils/analytics/umami";
+---
+
+<Analytics host={import.meta.env.HOST!} websiteId={import.meta.env.WEBSITE_ID!} />

--- a/apps/analytics/src/pages/pagetwo.astro
+++ b/apps/analytics/src/pages/pagetwo.astro
@@ -8,11 +8,11 @@ import Umami from "../components/Umami.astro";
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
+		<title>page two</title>
 		<Umami />
 	</head>
 	<body>
-		<h1>Astro</h1>
-		<a href="/pagetwo">page two</a>
+		<h1>page two</h1>
+		<a href="/">home</a>
 	</body>
 </html>

--- a/packages/analytics/src/umami/Umami.astro
+++ b/packages/analytics/src/umami/Umami.astro
@@ -7,4 +7,17 @@ type Props = {
 const { host, websiteId } = Astro.props;
 ---
 
-<script is:inline async src={host} data-website-id={websiteId}></script>
+<script is:inline async src={host} data-website-id={websiteId} data-auto-track="false"></script>
+<script>
+	import { usingViewTransitions } from "../utils";
+	if (!usingViewTransitions) {
+		// TODO: make this typed
+		const { umami } = window as any;
+		umami.track((props: any) => ({ ...props, url: document.location.pathname }));
+	}
+	document.addEventListener("astro:page-load", () => {
+		// TODO: make this typed
+		const { umami } = window as any;
+		umami.track((props: any) => ({ ...props, url: document.location.pathname }));
+	});
+</script>

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * use this to see if view transitions are currently enabled
+ * @internal
+ * @returns if using view transitions
+ */
+const _usingViewTransitions = () => {
+	const viewTransitionsMetaElem = document.head.querySelector("meta[name='astro-view-transitions-enabled']");
+	if (!viewTransitionsMetaElem) return false;
+	return true;
+};
+
+const usingViewTransitions = _usingViewTransitions();
+
+export { usingViewTransitions };


### PR DESCRIPTION
closes #3 

this fixes the issue where pageviews did not get tracked when you used view transitions